### PR TITLE
Attempt to fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - rcomp init # this should be removed eventually, bug with RComp
 
 install:
+  - sudo apt-get update
   - sudo apt-get -q install check valgrind
 
 script:


### PR DESCRIPTION
Travis seems to be complaining about missing packages. This performs a `apt-get
update` before attempting to install check and valgrind (which apt-get
suggests). Might fix the problem.
