### PR TITLE
Fix build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![marktab](docs/marktab.png)
 
-[![travis](https://travis-ci.org/cknadler/marktab.png "travis")](https://travis-ci.org/cknadler/marktab)
+[![Build Status](https://travis-ci.org/cknadler/marktab.png?branch=master)](https://travis-ci.org/cknadler/marktab)
 
 Concise, machine readable, guitar tabs.
 


### PR DESCRIPTION
The Travis build image wasn't defaulting to the master branch status.
