### PR TITLE
Fix .rcomp executable path

### DIFF
--- a/.rcomp
+++ b/.rcomp
@@ -1,3 +1,3 @@
 ---
-command: bin/marktab
+command: examples/cli
 directory: spec/rcomp


### PR DESCRIPTION
The old directory structure of marktab (from what I can tell) had an executable
in `bin`. `bin` no longer exists and the `cli` executable located at
`examples/cli` seems to now serve this purpose. This commit tells rcomp to test
against `examples/cli` instead of the old (it seems now nonexistant)
executable.

This allows the rcomp tests to run but none pass.
