### PR TITLE
Add install/uninstall target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ clean_examples:
 rebuild: clean all
 
 install: libmt
-	install -d $(LIB_DIR)
+	install -d $(INSTALL_PREFIX)/lib
 	install $(LIB_DIR)/libmt.a $(INSTALL_PREFIX)/lib/libmt.a
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ EXAMPLES_DIR = examples
 RCOMP_DIR = spec/rcomp
 CHECK_DIR = spec/check
 
+# Install Directories
+INSTALL_PREFIX = /usr/local
+
 # Sources
 LIBMT_SRCS = $(wildcard $(SRC_DIR)/*.c)
 
@@ -94,5 +97,12 @@ clean_examples:
 	make -C $(EXAMPLES_DIR) clean
 
 rebuild: clean all
+
+install: libmt
+	install -d $(LIB_DIR)
+	install $(LIB_DIR)/libmt.a $(INSTALL_PREFIX)/lib/libmt.a
+
+uninstall:
+	rm -f $(INSTALL_PREFIX)/lib/libmt.a
 
 .PHONY: clean test


### PR DESCRIPTION
For chuckles. To address #52.
Also, OSX ships a non GNU version of the install program. That was sort of a pain. I had to read the OSX man-page for install(1).
