### PR TITLE
Use abs() not fabs() as input is integer

### DIFF
--- a/src/mt_math.h
+++ b/src/mt_math.h
@@ -3,6 +3,6 @@
 
 #include <math.h>
 
-#define digits(num) (num == 0) ? 1 : (int) (floor(log10(fabs(num))) + 1)
+#define digits(num) (num == 0) ? 1 : (int) (floor(log10(abs(num))) + 1)
 
 #endif


### PR DESCRIPTION
Resolves compile failure on MacOS (Darwin 15.6.0) (Apple LLVM version 8.0.0 (clang-800.0.42.1))

src/mt_note.c:85:16: error: using floating point absolute value function 'fabs'
when argument is of integer type [-Werror,-Wabsolute-value]